### PR TITLE
Detect startup.jl

### DIFF
--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -92,8 +92,7 @@ called from a `using ReplGPT` call in the REPL or via `startup.jl`. It should re
 false when used in a script. 
 """
 function should_init_repl()
-    oldcheck = isdefined(Base, :active_repl)
-    oldcheck
+    isinteractive()
 end
 
 function init_repl()

--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -84,6 +84,18 @@ function call_chatgpt(s)
     end
 end
 
+"""
+    function should_init_repl()
+
+Check whether we should call `init_repl`. This function should return `true` when 
+called from a `using ReplGPT` call in the REPL or via `startup.jl`. It should return
+false when used in a script. 
+"""
+function should_init_repl()
+    oldcheck = isdefined(Base, :active_repl)
+    oldcheck
+end
+
 function init_repl()
 
     if ismissing(getAPIkey())
@@ -99,7 +111,7 @@ function init_repl()
     )
 end
 
-__init__() = isdefined(Base, :active_repl) ? init_repl() : nothing
+__init__() = should_init_repl() ? init_repl() : nothing
 
 
 end # module

--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -51,7 +51,7 @@ function clearAPIkey()
     @delete_preferences!(api_pref_name)
 end
 
-conversation = Vector{Dict{String, String}}()
+conversation = Vector{Dict{String,String}}()
 
 function call_chatgpt(s)
     key = getAPIkey()
@@ -59,11 +59,7 @@ function call_chatgpt(s)
         userMessage = Dict("role" => "user", "content" => s)
         push!(conversation, userMessage)
 
-        r = OpenAI.create_chat(
-            key,
-            "gpt-3.5-turbo",
-            conversation,
-        )
+        r = OpenAI.create_chat(key, "gpt-3.5-turbo", conversation)
 
         # TODO: check for errors!
         #if !=(r.status, 200)
@@ -79,7 +75,7 @@ function call_chatgpt(s)
         Markdown.parse(response)
     else
         Markdown.parse(
-            "OpenAI API key not found! Please set with `ReplGPT.setAPIkey(\"<YOUR OPENAI API KEY>\")` or set the environment variable $(api_key_name)=<YOUR OPENAI API KEY>"
+            "OpenAI API key not found! Please set with `ReplGPT.setAPIkey(\"<YOUR OPENAI API KEY>\")` or set the environment variable $(api_key_name)=<YOUR OPENAI API KEY>",
         )
     end
 end

--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -110,7 +110,25 @@ function init_repl()
     )
 end
 
-__init__() = should_init_repl() ? init_repl() : nothing
+function __init__()
+    if should_init_repl()
+        # if there exists an active REPL (ie, we're in the Julia shell and called `using ReplGPT`)
+        if isdefined(Base, :active_repl)
+            init_repl()
+        else # if there's no REPL yet, we might be in startup.jl
+            # adapted from https://github.com/MasonProtter/ReplMaker.jl/blob/7b4efadceb0ec268d7c6351add83094ca37776e2/README.md?plain=1#L245-L260
+            atreplinit() do repl
+                try
+                    init_repl()
+                catch
+                end
+            end
+        end
+
+    else
+        nothing
+    end
+end
 
 
 end # module


### PR DESCRIPTION
Adds some logic to detect if `using ReplGPT` was called in `startup.jl` and respond accordingly. ReplMaker.jl suggests using this `atreplinit` function and an `async` call to set up custom REPLs correctly when included in startup.jl and the suggestion seems to work well here!