### PR TITLE
Update Julia version for formatter check

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.3.0]
+        julia-version: [1.8.0]
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:


### PR DESCRIPTION
I think the format check is failing because the format-check template uses Julia 1.3.