### PR TITLE
Add ability to swap different chat models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Manifest.toml
 
 settings.json
+LocalPreferences.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Manifest.toml
+
+settings.json

--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -8,6 +8,7 @@ using Preferences
 
 include("formatting.jl")
 include("keys.jl")
+include("models.jl")
 
 """
     function ReplGPT.generate_empty_conversation()

--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -115,18 +115,19 @@ end
 
 function call_chatgpt(s)
     key = getAPIkey()
+    model = getmodelname()
     if !ismissing(key)
         userMessage = Dict("role" => "user", "content" => s)
         push!(conversation, userMessage)
 
-        r = OpenAI.create_chat(key, "gpt-3.5-turbo", conversation)
+        r = OpenAI.create_chat(key, model, conversation)
 
         # TODO: check for errors!
         while !=(r.status, 200)
             format("ChatGPT is busy! Do you want to try again? y/n")
             userreply = readline()
             if userreply == "y"
-                r = OpenAI.create_chat(key, "gpt-3.5-turbo", conversation)
+                r = OpenAI.create_chat(key, model, conversation)
             else
                 format("ChatGPT is busy! Do you want to try again?")
                 break

--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -121,8 +121,16 @@ function call_chatgpt(s)
         r = OpenAI.create_chat(key, "gpt-3.5-turbo", conversation)
 
         # TODO: check for errors!
-        #if !=(r.status, 200)
-        #  @test false
+        while ==(r.status, 100)
+            format("ChatGPT is busy! Do you want to try again? y/n")
+            userreply = readline()
+            if userreply == "y"
+                r = OpenAI.create_chat(key, "gpt-3.5-turbo", conversation)
+            else
+                format("ChatGPT is busy! Do you want to try again?")
+                break
+            end
+        end
         #end  
         response = r.response["choices"][begin]["message"]["content"]
 

--- a/src/ReplGPT.jl
+++ b/src/ReplGPT.jl
@@ -121,7 +121,7 @@ function call_chatgpt(s)
         r = OpenAI.create_chat(key, "gpt-3.5-turbo", conversation)
 
         # TODO: check for errors!
-        while ==(r.status, 100)
+        while !=(r.status, 200)
             format("ChatGPT is busy! Do you want to try again? y/n")
             userreply = readline()
             if userreply == "y"

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,0 +1,44 @@
+const api_model_name = "OPENAI_API_MODEL"
+const api_pref_model_name = "openai_api_model"
+
+"""
+    function getmodelname()
+
+Returns an OpenAI API model name to use from either the `LocalPreferences.toml` file or the
+`OPENAI_API_MODEL` environment variable. If neither is present, returns `gpt-3.5-turbo`.
+"""
+function getmodelname()
+    model = "gpt-3.5-turbo"
+
+    # try to load model from Preferences:
+    model = @load_preference(api_pref_model_name, "gpt-3.5-turbo")
+
+    # if not koaded from preferences, look in environment variables
+    if model == "gpt-3.5-turbo" && haskey(ENV, api_model_name)
+        model = ENV[api_model_name]
+    end
+
+    return model
+end
+
+"""
+    function setmodelname(model::String)
+
+Sets the OpenAI API model for ReplGPT to use. The model will be saved as plaintext to your environment's
+`LocalPreferences.toml` file (perhaps somewhere like `~/.julia/environments/v1.8/LocalPreferences.toml`).
+The model can be deleted with `ReplGPT.clearmodelname()`. 
+"""
+function setmodelname(model::String)
+    @set_preferences!(api_pref_model_name => model)
+end
+
+"""
+    function clearmodelname()
+
+Deletes the OpenAI API model saved in `LocalPreferences.toml` if present. 
+
+See also: ReplGPT.setmodelname(model::String)
+"""
+function clearmodelname()
+    @delete_preferences!(api_pref_model_name)
+end


### PR DESCRIPTION
Adds the ability to set the model being used for chatting. 
Users can run: `ReplGPT.setmodelname("gpt-4")` , in a similar way that they set API keys. 
to access different versions of  chat GPT. 